### PR TITLE
Fix markdown of Python Kalinigrad

### DIFF
--- a/expertise/python.md
+++ b/expertise/python.md
@@ -1,7 +1,7 @@
 # Python
 
 ## Python Kaliningrad
--[Telegram-чат](https://t.me/pythonkaliningrad) - https://t.me/pythonkaliningrad
+- [Telegram-чат](https://t.me/pythonkaliningrad) - https://t.me/pythonkaliningrad
 
 ## Minsk Python Meetup
 - [Сайт](https://minskpython.github.io/) - https://minskpython.github.io/


### PR DESCRIPTION
Before:
<img width="424" alt="Снимок экрана 2024-07-15 в 17 38 37" src="https://github.com/user-attachments/assets/efa3aee6-45fc-4743-9514-c7f8239f8fda">


After:
<img width="460" alt="Снимок экрана 2024-07-15 в 17 38 30" src="https://github.com/user-attachments/assets/b011a1fb-2402-43d8-b070-30749a00efd4">

